### PR TITLE
Dispatch userLoaded event when user is loaded from storage

### DIFF
--- a/src/store/create-store-module.js
+++ b/src/store/create-store-module.js
@@ -26,7 +26,7 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
       'userSignedOut'
     ]
     userManagerEvents.forEach(eventName => {
-      addUserManagerEventListener(oidcUserManager, eventName, () => { dispatchCustomBrowserEvent(eventName) })
+      addUserManagerEventListener(oidcUserManager, eventName, (e) => { dispatchCustomBrowserEvent(eventName, e.detail || {}) })
     })
   }
 
@@ -105,6 +105,14 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
             }
           } else {
             context.dispatch('oidcWasAuthenticated', user);
+            if (!isAuthenticatedInStore) {
+              if (oidcEventListeners && typeof oidcEventListeners.userLoaded === 'function') {
+                oidcEventListeners.userLoaded(user);
+              }
+              if (storeSettings.dispatchEventsOnWindow) {
+                dispatchCustomBrowserEvent('userLoaded', user)
+              }
+            }
           }
           resolve(hasAccess)
         })


### PR DESCRIPTION
Issue: #31 

oidc-client does not dispatch it’s userLoaded event when we get the user from storage. However, vuex-oidc has the capability of dispatching it’s userLoaded event since it can keep track of if the user was already loaded into the vuex store or not before the user was loaded from the store.

Not super obvious that this should be done since oidc-client does not do this, but I think we can argue that it would be useful. This also will fix implementations of vuex-oidc that rely on the event being dispatch like it was when the authentication was made even when a valid token existed in storage. Like described in issue 31.