### PR TITLE
Added typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,115 @@
+import { ActionContext, Module, Store } from 'vuex';
+import { OidcClientSettings, User, UserManager } from 'oidc-client';
+import { Route, RouteConfig } from 'vue-router';
+
+export interface VuexOidcClientSettings extends OidcClientSettings {
+  authority: string;
+  clientId: string;
+  redirectUri: string;
+  responseType: string;
+  scope: string;
+  maxAge?: string;
+  uiLocales?: string;
+  loginHint?: string;
+  acrValues?: string;
+  postLogoutRedirectUri?: string;
+  popupRedirectUri?: string;
+  silentRedirectUri?: string;
+}
+
+export interface VuexOidcStoreSettings {
+  namespaced?: boolean;
+  dispatchEventsOnWindow?: boolean;
+}
+
+export interface VuexOidcStoreListeners {
+  userLoaded?: (user: User) => void;
+  userUnloaded?: () => void;
+  accessTokenExpiring?: () => void;
+  accessTokenExpired?: () => void;
+  silentRenewError: () => void;
+  userSignedOut?: () => void;
+}
+
+export interface VuexOidcState {
+  access_token: string | null;
+  id_token: string | null;
+  user: any | null;
+  scopes: string[] | null;
+  is_checked: boolean;
+  events_are_bound: boolean;
+  error: string | null;
+}
+
+export function vuexOidcCreateUserManager(settings: VuexOidcClientSettings): UserManager;
+
+export function vuexOidcCreateStoreModule(
+  settings: VuexOidcClientSettings,
+  storeSettings?: VuexOidcStoreSettings,
+  listeners?: VuexOidcStoreListeners,
+): Module<VuexOidcState, any>;
+
+export function vuexOidcCreateNuxtRouterMiddleware(namespace?: string): any;
+
+export function vuexOidcCreateRouterMiddleware(store: Store<any>, namespace?: string): any;
+
+export function vuexOidcProcessSilentSignInCallback(): void;
+
+export namespace vuexOidcUtils {
+  export function objectAssign(objs: any[]): any;
+
+  export function parseJwt<T extends object>(jwt: string): T;
+
+  export function firstLetterUppercase(str: string): string;
+
+  export function camelCaseToSnakeCase(str: string): string;
+}
+
+export function vuexDispatchCustomBrowserEvent<T>(
+  name: string,
+  detail?: T,
+  params?: EventInit,
+): any;
+
+// The following types are not exposed directly, they are part of the store
+// and mostly for reference, or for use with vuex-class.
+
+export interface VuexOidcStoreGetters {
+  readonly oidcIsAuthenticated: boolean;
+  readonly oidcUser: any | null;
+  readonly oidcAccessToken: string | null;
+  readonly oidcAccessTokenExp: number | null;
+  readonly oidcScopes: string[] | null;
+  readonly oidcIdToken: string | null;
+  readonly oidcIdTokenExp: number | null;
+  readonly oidcAuthenticationIsChecked: boolean | null;
+  readonly oidcError: string | null;
+  readonly oidcIsRoutePublic: (route: RouteConfig) => boolean;
+}
+
+export interface VuexOidcStoreActions {
+  oidcCheckAccess: (route: Route) => Promise<boolean>;
+  authenticateOidc: (redirectPath: string) => void;
+  oidcSignInCallback: () => Promise<string>;
+  authenticateOidcSilent: () => void;
+  oidcWasAuthenticated: (user: User) => void;
+  getOidcUser: () => void;
+  addOidcEventListener: (payload: {
+    eventName: string;
+    eventListener: (...args: any[]) => void;
+  }) => void;
+  removeOidcEventListener: (payload: {
+    eventName: string;
+    eventListener: (...args: any[]) => void;
+  }) => void;
+  signOutOidc: () => void;
+}
+
+export interface VuexOidcStoreMutations {
+  setOidcAuth: (user: User) => void;
+  setOidcUser: (user: User) => void;
+  unsetOidcAuth: () => void;
+  setOidcAuthIsChecked: () => void;
+  setOidcEventsAreBound: () => void;
+  setOidcError: (err: Error | string | null) => void;
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "main": "dist/vuex-oidc.cjs.js",
   "module": "dist/vuex-oidc.esm.js",
+  "typings": "index.d.ts",
   "peerDependencies": {
     "vue": ">= 2.5.0",
     "vuex": ">= 3.0.0",
@@ -52,6 +53,7 @@
     "preversion": "npm test"
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ]
 }


### PR DESCRIPTION
All exports are typed fully (or to the best of my ability), and I've included some extra typings to describe the store getters, mutations & actions. The extra typings are written to be compatible with `vuex-class`, using something like this:

```ts
import Vue from 'vue';
import Component from 'vue-class-component';
import { namespace } from 'vuex-class';
import { VuexOidcStoreActions } from 'vuex-oidc';

const oidc = namespace('oidc'); // The namespace the vuex-oidc module is under.

@Component
export class OidcCallback extends Vue {
  @oidc.Action('oidcSignInCallback')
  oidcSignInCallback: VuexOidcStoreActions['oidcSignInCallback'];

  created () {
    this.oidcSignInCallback()
      .then(redirectTo => this.$router.push(redirectPath))
      .catch(err => {
        console.error(err);
        this.$router.push('/login/error');
      }
  }
}
```

@perarnborg I'm happy to remove these extra typings if you don't think they should be here. I can also adjust them to be namespaces instead so you can access them via dot notation (you can't with interfaces, but I went with them so it lined up with the package better).

I've resorted to using `any` for a few things which are very difficult to type nicely, but it's only a couple of places and so should be alright.

@coolhome Might be worth you having a look over to see if it lines up 100%.

Closes #12