### PR TITLE
Add isPublicRoute option to store in order to customize check from client

### DIFF
--- a/src/store/create-store-module.js
+++ b/src/store/create-store-module.js
@@ -68,6 +68,9 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
     if (storeSettings.publicRoutePaths) {
       return storeSettings.publicRoutePaths.map(path => path.replace(/\/$/, '')).indexOf(route.path.replace(/\/$/, '')) > -1
     }
+    if (storeSettings.isPublicRoute && typeof storeSettings.isPublicRoute === 'function') {
+      return storeSettings.isPublicRoute(route);
+    }
     return false
   }
 

--- a/test/create-store-module.test.js
+++ b/test/create-store-module.test.js
@@ -128,6 +128,29 @@ describe('createStoreModule', function() {
         })
     });
   });
+
+  describe('.getters.oidcIsRoutePublic', function() {
+    it('should not call isPublicRoute when not a function', function() {
+      const route = {
+        path: '/',
+        meta: {}
+      };
+      storeModule = vuexOidc.vuexOidcCreateStoreModule(oidcConfig, {isPublicRoute: 'not a function'});
+      assert.equal(storeModule.getters.oidcIsRoutePublic(storeModule.state)(route), false);
+    });
+
+    it('should call isPublicRoute', function() {
+      const route = {
+        path: '/',
+        meta: {}
+      };
+      const isPublicRoute = sinon.stub().returns(true);
+
+      storeModule = vuexOidc.vuexOidcCreateStoreModule(oidcConfig, {isPublicRoute});
+      assert.equal(storeModule.getters.oidcIsRoutePublic(storeModule.state)(route), true);
+      assert.equal(isPublicRoute.calledWith(route), true);
+    });
+  });
 });
 
 function authenticatedContext() {


### PR DESCRIPTION
Hello,

This PR adds support to situations where something else than `isPublic` flag or `publicRoutePaths` array is required to check if the route is public.

```js
vuexOidc.vuexOidcCreateStoreModule(oidcConfig, {isPublicRoute: (route) => /* do any check you want*/ return true;});
```

Also added some unit tests for the getter.