### PR TITLE
Add storeOidcUser to actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # vuex-oidc changelog
 
+## Unreleased
+
+### Features
+* Add `storeOidcUser` to actions
+
 ## 3.4.0
 *2019-12-30*
 

--- a/src/store/create-store-module.js
+++ b/src/store/create-store-module.js
@@ -232,6 +232,17 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
       }
       context.commit('setOidcAuthIsChecked')
     },
+    storeOidcUser (context, user) {
+      return oidcUserManager.storeUser(user)
+        .then(() => oidcUserManager.getUser())
+        .then(user => context.dispatch('oidcWasAuthenticated', user))
+        .then(() => {})
+        .catch(err => {
+          context.commit('setOidcError', errorPayload('storeOidcUser', err))
+          context.commit('setOidcAuthIsChecked')
+          throw err
+        })
+    },
     getOidcUser (context) {
       /* istanbul ignore next */
       return oidcUserManager.getUser().then(user => {


### PR DESCRIPTION
We use this functionality to inject a token directly into the `UserManager` in E2E tests where the token is fetched via `grant_type` `password`.