### PR TITLE
Add clearStaleState action

### DIFF
--- a/src/store/create-store-module.js
+++ b/src/store/create-store-module.js
@@ -262,6 +262,9 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
       return oidcUserManager.removeUser().then(() => {
         context.commit('unsetOidcAuth')
       })
+    },
+    clearStaleState () {
+      return oidcUserManager.clearStaleState()
     }
   }
 


### PR DESCRIPTION
Added clearStaleState action that removes stale state entries in storage for incomplete authorize requests.

LocalStorage has some limitations for stored data and it may become full sometime. So we need an ability to clear old entries