### PR TITLE
Add isAuthenticatedBy setting to not require an id_token

### DIFF
--- a/src/store/create-store-module.js
+++ b/src/store/create-store-module.js
@@ -6,7 +6,10 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
   const oidcConfig = getOidcConfig(oidcSettings)
   const oidcUserManager = createOidcUserManager(oidcSettings)
   storeSettings = objectAssign([
-    { namespaced: false },
+    {
+      namespaced: false,
+      isAuthenticatedBy: 'id_token'
+    },
     storeSettings
   ])
   const oidcCallbackPath = getOidcCallbackPath(oidcConfig.redirect_uri, storeSettings.routeBase || '/')
@@ -46,9 +49,10 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
   }
 
   const isAuthenticated = (state) => {
-    if (state.id_token) {
+    if (state[storeSettings.isAuthenticatedBy]) {
       return true
     }
+
     return false
   }
 


### PR DESCRIPTION
... to be "authenticated"

I wanted to play around with this, after you suggested it yourself in #91. I haven't checked the behavior when the access_token times out, but at least renewing the access_token by clicking on the "Reauthenticate silently" button seems to work just fine.

edit:
Automatic renewal seems to work fine too.