### PR TITLE
small change to make native ESM loading working

### DIFF
--- a/src/services/oidc-helpers.js
+++ b/src/services/oidc-helpers.js
@@ -1,8 +1,8 @@
 import { objectAssign, parseJwt, firstLetterUppercase, camelCaseToSnakeCase } from './utils'
-import { UserManager, WebStorageStateStore } from 'oidc-client'
+import oidc from 'oidc-client'
 
 const defaultOidcConfig = {
-  userStore: new WebStorageStateStore(),
+  userStore: new oidc.WebStorageStateStore(),
   loadUserInfo: true,
   automaticSilentSignin: true
 }
@@ -61,7 +61,7 @@ export const createOidcUserManager = (oidcSettings) => {
       throw new Error('Required oidc setting ' + requiredProperty + ' missing for creating UserManager')
     }
   })
-  return new UserManager(oidcConfig)
+  return new oidc.UserManager(oidcConfig)
 }
 
 export const addUserManagerEventListener = (oidcUserManager, eventName, eventListener) => {
@@ -79,7 +79,7 @@ export const removeUserManagerEventListener = (oidcUserManager, eventName, event
 }
 
 export const processSilentSignInCallback = () => {
-  new UserManager().signinSilentCallback()
+  new oidc.UserManager().signinSilentCallback()
 }
 
 export const processSignInCallback = (oidcSettings) => {


### PR DESCRIPTION
May I suggest a slight modification - most probably without negative impact?

I did this change locally to get a vue#3.0.0-rc.5 (with 

- vuex#4.0.0-beta.4, 
- vue-router#4.0.0-beta.4, 
- vuex-oidc#3.7.0 and 
- oidc-client#1.10.1

) app on vitejs working.

I'm not completely sure about this as I'm still a JS noob, especially if it gets down to the bundling / tooling stuff :)