### PR TITLE
Add automaticSilentRenewError event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,7 @@ export interface VuexOidcStoreListeners {
   silentRenewError?: () => void;
   userSignedOut?: () => void;
   oidcError?: () => void;
+  automaticSilentRenewError?: () => void;
 }
 
 export interface VuexOidcState {

--- a/src/store/create-store-module.js
+++ b/src/store/create-store-module.js
@@ -421,7 +421,7 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
   }
 
   const dispatchCustomErrorEvent = (eventName, payload) => {
-    // oidcError and automaticSilentRenewError are not a userManagementEvent, they are events implemeted in vuex-oidc,
+    // oidcError and automaticSilentRenewError are not UserManagement events, they are events implemeted in vuex-oidc,
     if (typeof oidcEventListeners[eventName] === 'function') {
       oidcEventListeners[eventName](payload)
     }

--- a/src/store/create-store-module.js
+++ b/src/store/create-store-module.js
@@ -278,7 +278,12 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
       if (!context.state.events_are_bound) {
         oidcUserManager.events.addAccessTokenExpired(() => { context.commit('unsetOidcAuth') })
         if (oidcSettings.automaticSilentRenew) {
-          oidcUserManager.events.addAccessTokenExpiring(() => { context.dispatch('authenticateOidcSilent') })
+          oidcUserManager.events.addAccessTokenExpiring(() => {
+            context.dispatch('authenticateOidcSilent')
+              .catch((err) => {
+                dispatchCustomErrorEvent('automaticSilentRenewError', errorPayload('authenticateOidcSilent', err))
+              })
+          })
         }
         context.commit('setOidcEventsAreBound')
       }
@@ -404,7 +409,7 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
     },
     setOidcError (state, payload) {
       state.error = payload.error
-      dispatchErrorEvent(payload)
+      dispatchCustomErrorEvent('oidcError', payload)
     }
   }
 
@@ -415,13 +420,13 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
     }
   }
 
-  const dispatchErrorEvent = payload => {
-    // oidcError is not a userManagementEvent, it is an event implemeted in vuex-oidc,
-    if (typeof oidcEventListeners.oidcError === 'function') {
-      oidcEventListeners.oidcError(payload)
+  const dispatchCustomErrorEvent = (eventName, payload) => {
+    // oidcError and automaticSilentRenewError are not a userManagementEvent, they are events implemeted in vuex-oidc,
+    if (typeof oidcEventListeners[eventName] === 'function') {
+      oidcEventListeners[eventName](payload)
     }
     if (storeSettings.dispatchEventsOnWindow) {
-      dispatchCustomBrowserEvent('oidcError', payload)
+      dispatchCustomBrowserEvent(eventName, payload)
     }
   }
 


### PR DESCRIPTION
Enables catching failed automatic silent signins discussed in #125 

App can register event listener on automaticSilentRenewError, either by passing it in oidcEventListeners when creating the store module, or by listening to the vuex:automaticSilentRenewError event on window.