### PR TITLE
Silent Renew - Failure - Not Recovering

### DIFF
--- a/src/store/create-store-module.js
+++ b/src/store/create-store-module.js
@@ -197,7 +197,7 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
                 authenticateOidcSilent(context, { ignoreErrors: true })
                   .then(() => {
                     oidcUserManager.getUser().then(user => {
-                      if (!user) {
+                      if (!user || user.expired) {
                         authenticate()
                       }
                       resolve(!!user)


### PR DESCRIPTION
Problem:
User loads application, local storage access token is expired. 

`oidcCheckAccess` is triggered, getUserPromise resolved a user that user.expired is set. `authenticateOidcSilent()` is triggered which will always resolve regardless of error. In this case my error is `login_required` from the IdP. The `oidcUserManager.getUser()` is returning the already loaded user and fails to trigger a full login.

Solution:
Check for expired token during a silent failure and trigger a redirect signin.

Possible fix for #129