### PR TITLE
Add startSilentRenew and stopSilentRenew actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 dist
 .nyc_output
+.idea

--- a/src/store/create-store-module.js
+++ b/src/store/create-store-module.js
@@ -390,6 +390,12 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
     },
     clearStaleState () {
       return oidcUserManager.clearStaleState()
+    },
+    startSilentRenew () {
+      return oidcUserManager.startSilentRenew()
+    },
+    stopSilentRenew () {
+      return oidcUserManager.stopSilentRenew()
     }
   }
 


### PR DESCRIPTION
Useful when user is offline to prevent silent renew and logout redirect.

From [oidc-client docs](https://github.com/IdentityModel/oidc-client-js/wiki):
* startSilentRenew [1.4.0]: Enables silent renew for the UserManager.
* stopSilentRenew [1.4.0]: Disables silent renew for the UserManager.