### PR TITLE
Replace oidc-client with oidc-client-ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # vuex-oidc changelog
 
 ## 4.0.0
-*2022-MM-DD*
+*Unreleased*
 
 ### Breaking Changes
 * oidc-client-ts instead of oidc-client is now a required peer dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # vuex-oidc changelog
 
+## 4.0.0
+*2022-MM-DD*
+
+### Breaking Changes
+* oidc-client-ts instead of oidc-client is now a required peer dependency
+  The Authorized Code Flow instead of the Implicit Flow is the only supported OAuth flow type
+
 ## 3.10.2
 *2021-02-09*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Breaking Changes
 * oidc-client-ts instead of oidc-client is now a required peer dependency
   The Authorized Code Flow instead of the Implicit Flow is the only supported OAuth flow type
+* `vuexOidcProcessSilentSignInCallback`, which previously takes no arguments, now needs the oidcSettings as an argument.
+
 ## 3.11.0
 *2022-06-30*
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Vue.js implementation of [oidc-client](https://github.com/IdentityModel/oidc-cli
 
 ## Documentation
 
-See the [wiki](https://github.com/perarnborg/vuex-oidc/wiki) for doumentation on how to implement vuex-oidc.
+See the [wiki](https://github.com/perarnborg/vuex-oidc/wiki) for documentation on how to implement vuex-oidc.
 
 ## Examples
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ export function vuexOidcCreateNuxtRouterMiddleware(namespace?: string): any;
 
 export function vuexOidcCreateRouterMiddleware(store: Store<any>, namespace?: string): any;
 
-export function vuexOidcProcessSilentSignInCallback(): Promise<void>;
+export function vuexOidcProcessSilentSignInCallback(settings: VuexOidcClientSettings): Promise<void>;
 
 export function vuexOidcProcessSignInCallback(settings: VuexOidcClientSettings): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ import { Route, RouteConfig } from 'vue-router';
 export interface VuexOidcClientSettings extends OidcClientSettings {
   authority: string;
   clientId: string;
+  clientSecret?: string;
   redirectUri: string;
   responseType: string;
   scope: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1366,12 +1366,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1587,12 +1581,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "core-js": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.14.0.tgz",
-      "integrity": "sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA==",
-      "dev": true
-    },
     "core-js-compat": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.14.0.tgz",
@@ -1660,9 +1648,9 @@
       }
     },
     "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
       "dev": true
     },
     "cssom": {
@@ -3053,6 +3041,12 @@
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3620,17 +3614,14 @@
         "es-abstract": "^1.18.2"
       }
     },
-    "oidc-client": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
-      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
+    "oidc-client-ts": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.0.4.tgz",
+      "integrity": "sha512-Au7wSMNVxDFkxPdacNZfQVDmtuHNGkT9EbMvCQyjoDFOv229+gFQ1b7Xjza4O27RRwxb8bD/kmQ3IC+pDoHiHw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.4.1",
-        "base64-js": "^1.5.1",
-        "core-js": "^3.8.3",
-        "crypto-js": "^4.0.0",
-        "serialize-javascript": "^4.0.0"
+        "crypto-js": "^4.1.1",
+        "jwt-decode": "^3.1.2"
       }
     },
     "once": {
@@ -3851,15 +3842,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
-    },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -4180,15 +4162,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
-    },
-    "serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "module": "dist/vuex-oidc.esm.js",
   "typings": "index.d.ts",
   "peerDependencies": {
-    "oidc-client": ">= 1.10.1",
+    "oidc-client-ts": ">= 2.0.0",
     "vue": ">= 2.5.0",
     "vuex": ">= 3.0.0"
   },
@@ -38,7 +38,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "jsdom": "^15.1.1",
-    "oidc-client": ">= 1.10.1",
+    "oidc-client-ts": ">= 2.0.0",
     "mocha": "^6.2.0",
     "node-storage-shim": "^2.0.0",
     "nyc": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "vue oidc",
     "vue open id"
   ],
-  "version": "3.11.1",
+  "version": "4.0.0",
   "homepage": "https://github.com/perarnborg/vuex-oidc#readme",
   "license": "MIT",
   "repository": {

--- a/src/services/oidc-helpers.js
+++ b/src/services/oidc-helpers.js
@@ -17,6 +17,7 @@ const requiredConfigProperties = [
 
 const settingsThatAreSnakeCasedInOidcClient = [
   'clientId',
+  'clientSecret',
   'redirectUri',
   'responseType',
   'maxAge',

--- a/src/services/oidc-helpers.js
+++ b/src/services/oidc-helpers.js
@@ -1,8 +1,8 @@
 import { objectAssign, parseJwt, firstLetterUppercase, camelCaseToSnakeCase } from './utils'
-import oidc from 'oidc-client'
+import { UserManager, WebStorageStateStore } from 'oidc-client-ts'
 
 const defaultOidcConfig = {
-  userStore: new oidc.WebStorageStateStore(),
+  userStore: new WebStorageStateStore(),
   loadUserInfo: true,
   automaticSilentSignin: true
 }
@@ -61,7 +61,7 @@ export const createOidcUserManager = (oidcSettings) => {
       throw new Error('Required oidc setting ' + requiredProperty + ' missing for creating UserManager')
     }
   })
-  return new oidc.UserManager(oidcConfig)
+  return new UserManager(oidcConfig)
 }
 
 export const addUserManagerEventListener = (oidcUserManager, eventName, eventListener) => {
@@ -78,8 +78,8 @@ export const removeUserManagerEventListener = (oidcUserManager, eventName, event
   }
 }
 
-export const processSilentSignInCallback = () => {
-  return new oidc.UserManager().signinSilentCallback()
+export const processSilentSignInCallback = (oidcSettings) => {
+  return new createOidcUserManager(oidcSettings).signinSilentCallback()
 }
 
 export const processSignInCallback = (oidcSettings) => {

--- a/src/services/oidc-helpers.js
+++ b/src/services/oidc-helpers.js
@@ -79,7 +79,7 @@ export const removeUserManagerEventListener = (oidcUserManager, eventName, event
 }
 
 export const processSilentSignInCallback = (oidcSettings) => {
-  return new createOidcUserManager(oidcSettings).signinSilentCallback()
+  return createOidcUserManager(oidcSettings).signinSilentCallback()
 }
 
 export const processSignInCallback = (oidcSettings) => {

--- a/test/create-store-module.test.js
+++ b/test/create-store-module.test.js
@@ -10,7 +10,7 @@ describe('createStoreModule', function() {
   before(function () {
     vuexOidc = require('../dist/vuex-oidc.cjs');
     storeModule = vuexOidc.vuexOidcCreateStoreModule(oidcConfig, {dispatchEventsOnWindow: true});
-    UserManager = require('oidc-client').UserManager;
+    UserManager = require('oidc-client-ts').UserManager;
   });
 
   afterEach(function () {

--- a/test/oidc-helper.test.js
+++ b/test/oidc-helper.test.js
@@ -34,10 +34,12 @@ describe("oidcHelper.createOidcUserManager", function () {
     const camelCaseOidcConfig = {
       ...oidcConfig,
       clientId: oidcConfig.client_id,
+      clientSecret: oidcConfig.client_secret,
       redirectUri: oidcConfig.redirect_uri,
       responseType: oidcConfig.response_type,
     };
     delete camelCaseOidcConfig.client_id;
+    delete camelCaseOidcConfig.client_secret;
     delete camelCaseOidcConfig.redirect_uri;
     delete camelCaseOidcConfig.response_type;
     let userManager;


### PR DESCRIPTION
With big thanks to the maintainer of `oidc-client`, brockallen, this replaces the `oidc-client` library with its successor, [`oidc-client-ts`](https://github.com/authts/oidc-client-ts). [`oidc-client`](https://github.com/IdentityModel/oidc-client-js) is no longer maintained, and  it is not quite desirable to continue relying on abandoned libraries, especially for security sensitive authn/authz software.

The reasons that the migration the dependency from oidc-client to oidc-client-ts can be justified are as follow:

- oidc-client-ts is actively maintained:
  https://github.com/authts/oidc-client-ts/pulse
- The [APIs](https://authts.github.io/oidc-client-ts/) are mostly compatible with those of oidc-client. 
- They provide a detailed migration guide for the users of oidc-client:
  https://github.com/authts/oidc-client-ts/blob/main/docs/migration.md
- The maintainer of oidc-client recommends migration to oidc-client-ts:
  https://github.com/IdentityModel/oidc-client-js#:~:text=A%20successor%20project%20that%20is%20showing%20great%20progress%20in%20updating%20and%20modernizing%20is%20%22oidc%2Dclient%2Dts%22%20and%20can%20be%20found%20here.
  > A successor project that is showing great progress in updating and modernizing is "oidc-client-ts" and can be found [here](https://github.com/authts/oidc-client-ts).
- oidc-client and oidc-client-ts are both licensed under the Apache License 2.0. No license issues.

A downside is that oidc-client-ts does not support the OAuth 2.0 Implicit Flow.
oidc-client-ts suports the Implicit Flow and the Authorization Code Flow with PKCE, while oidc-client-ts only supports the Authorization Code Flow with PKCE and Refresh Token Grant.
Existing users of vuex-oidc might need to tweak some configurations of their identity providers to change the auth flow type.
However, OIDC service providers such as Microsoft and Auth0 nowadays recommend against the use of the Implicit Flow and encourage switching to the Authorization Code Flow with PKCE 
(or some other alternatives) even for SPAs. [Microsoft Authentication Library for JavaScript (MSAL.js) v2](https://github.com/AzureAD/microsoft-authentication-library-for-js), for example, has dropped support for the OAuth 2.0 Implicit Grant Flow.


In one of my Vue.js SPAs at work, I have experimentally switched from vuex-oidc with oidc-client to vuex-oidc with oidc-client-ts. The migration was quite smooth; I only needed to enable refresh tokens in AzureAD and slightly change the configurations for vuex-oidc as follows: 

```diff
import { vuexOidcCreateStoreModule } from 'vuex-oidc'
- import Oidc from 'oidc-client'
+ import { Logger, Log } from 'oidc-client-ts'

- Oidc.Log.logger = window.console
- Oidc.Log.level = process.env.NODE_ENV === 'development' ? Oidc.Log.DEBUG : Oidc.Log.WARN
+ Log.setLogger(window.console)
+ if (process.env.NODE_ENV === 'development') {
+   Log.setLevel(Log.DEBUG)
+ } else {
+   Log.setLevel(Log.WARN)
+ }

export const oidcSettings = {
  authority: `https://${process.env.oidcHost}/v2.0`,
  clientId: process.env.clientId,
  redirectUri: process.env.redirectUri,
- responseType: 'id_token token',
+ responseType: 'code',
- scope: 'openid profile',
+ scope: 'openid profile offline_access',
  automaticSilentRenew: true,
  validateSubOnSilentRenew: true,
  automaticSilentSignin: true,
  includeIdTokenInSilentRenew: true,
- revokeAccessTokenOnSignout: true
+ revokeTokensOnSignout: true
}
```

This has been working well in an Authorization Code Flow with PKCE and access token auto-refresh setup.


To help migration by the existing users of the vuex-oidc, I have also prepared some changes to the wiki of this repository:

https://github.com/mmizutani/vuex-oidc/wiki/Home/_compare/d9bb6cb0855e83464435bbf2042b7eac48f5b48c...d6da010b8af3a8ac2b1a2a8156f05972624f50e2

If the backward-incompatible changes introduced by this PR is not acceptable, we might consider adding a user-configurable parameter to select which of the OIDC client libraries to use to vuex-oidc.


Resolve #177