### PR TITLE
Allow not removing user when tokens expire

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,7 @@ export interface VuexOidcStoreSettings {
   defaultSigninSilentOptions?: VuexOidcSigninSilentOptions;
   defaultSigninPopupOptions?: VuexOidcSigninPopupOptions;
   isAuthenticatedBy?: 'access_token'|'id_token';
+  removeUserWhenTokensExpire?: boolean
 }
 
 export interface VuexOidcErrorPayload {

--- a/test/oidc-helper.test.js
+++ b/test/oidc-helper.test.js
@@ -1,44 +1,41 @@
-const assert = require('assert');
-const oidcConfig = require('./oidcTestConfig');
+const assert = require("assert");
+const oidcConfig = require("./oidcTestConfig");
 let vuexOidc;
 
-describe('oidcHelper.createOidcUserManager', function() {
+describe("oidcHelper.createOidcUserManager", function () {
   before(function () {
-    vuexOidc = require('../dist/vuex-oidc.cjs');
+    vuexOidc = require("../dist/vuex-oidc.cjs");
   });
 
-  it('should create a UserManager', function() {
-    const userManager = vuexOidc.vuexOidcCreateUserManager(oidcConfig)
-    assert.equal(typeof userManager, 'object')
+  it("should create a UserManager", function () {
+    const userManager = vuexOidc.vuexOidcCreateUserManager(oidcConfig);
+    assert.equal(typeof userManager, "object");
   });
-  [
-    'authority',
-    'client_id',
-    'redirect_uri',
-    'response_type',
-    'scope'
-  ].forEach((requiredSetting) => {
-    it('should fail without oidc required setting ' + requiredSetting, function() {
-      const faultyOidcConfig = {
-        ...oidcConfig
-      };
-      delete faultyOidcConfig[requiredSetting];
-      let userManager;
+  ["authority", "client_id", "redirect_uri", "response_type", "scope"].forEach(
+    (requiredSetting) => {
+      it(
+        "should fail without oidc required setting " + requiredSetting,
+        function () {
+          const faultyOidcConfig = {
+            ...oidcConfig,
+          };
+          delete faultyOidcConfig[requiredSetting];
+          let userManager;
 
-      try {
-        userManager = vuexOidc.vuexOidcCreateUserManager(faultyOidcConfig);
-      }
-      catch(error) {
-      }
-      assert.notEqual(typeof userManager, 'object');
-    });
-  });
-  it('should translate settings that are snake_case in oidc-client from camelCase ', function() {
+          try {
+            userManager = vuexOidc.vuexOidcCreateUserManager(faultyOidcConfig);
+          } catch (error) {}
+          assert.notEqual(typeof userManager, "object");
+        }
+      );
+    }
+  );
+  it("should translate settings that are snake_case in oidc-client from camelCase ", function () {
     const camelCaseOidcConfig = {
       ...oidcConfig,
       clientId: oidcConfig.client_id,
       redirectUri: oidcConfig.redirect_uri,
-      responseType: oidcConfig.response_type
+      responseType: oidcConfig.response_type,
     };
     delete camelCaseOidcConfig.client_id;
     delete camelCaseOidcConfig.redirect_uri;
@@ -47,31 +44,46 @@ describe('oidcHelper.createOidcUserManager', function() {
 
     try {
       userManager = vuexOidc.vuexOidcCreateUserManager(camelCaseOidcConfig);
-    }
-    catch(error) {
-    }
-    assert.equal(typeof userManager, 'object')
+    } catch (error) {}
+    assert.equal(typeof userManager, "object");
   });
 });
 
-describe('oidcHelper.getOidcCallbackPath', function() {
+describe("oidcHelper.getOidcCallbackPath", function () {
   before(function () {
-    vuexOidc = require('../dist/vuex-oidc.cjs');
+    vuexOidc = require("../dist/vuex-oidc.cjs");
   });
 
-  it('should return path when router base is /', function() {
-    const path = vuexOidc.vuexOidcGetOidcCallbackPath(oidcConfig.redirect_uri, '/');
-    assert.equal(path, '/oidc-callback');
+  it("should return path when router base is /", function () {
+    const path = vuexOidc.vuexOidcGetOidcCallbackPath(
+      oidcConfig.redirect_uri,
+      "/"
+    );
+    assert.equal(path, "/oidc-callback");
   });
 
-  it('should return path when router base is not /', function() {
-    const routeBase = '/app/';
-    const path = vuexOidc.vuexOidcGetOidcCallbackPath('http://localhost:1337' + routeBase + 'oidc-callback', routeBase)
-    assert.equal(path, '/oidc-callback')
+  it("should return path when redirect_uri includes a sub path", function () {
+    const path = vuexOidc.vuexOidcGetOidcCallbackPath(
+      oidcConfig.redirect_uri.replace('/oidc-callback', '/auth/oidc-callback'),
+      "/"
+    );
+    assert.equal(path, "/auth/oidc-callback");
   });
 
-  it('should return path without trailing /', function() {
-    const path = vuexOidc.vuexOidcGetOidcCallbackPath('http://localhost:1337/oidc-callback/', '/')
-    assert.equal(path, '/oidc-callback')
+  it("should return path when router base is not /", function () {
+    const routeBase = "/app/";
+    const path = vuexOidc.vuexOidcGetOidcCallbackPath(
+      "http://localhost:1337" + routeBase + "oidc-callback",
+      routeBase
+    );
+    assert.equal(path, "/oidc-callback");
+  });
+
+  it("should return path without trailing /", function () {
+    const path = vuexOidc.vuexOidcGetOidcCallbackPath(
+      "http://localhost:1337/oidc-callback/",
+      "/"
+    );
+    assert.equal(path, "/oidc-callback");
   });
 });


### PR DESCRIPTION
A store setting called `removeUserWhenTokensExpire` is added, to optionaly enable behaviour asked for in #182 