### PR TITLE
Use user managers expires_at value to expire access tokens

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,7 @@ export interface VuexOidcState {
   access_token: string | null;
   id_token: string | null;
   user: any | null;
+  expires_at: number | null;
   scopes: string[] | null;
   is_checked: boolean;
   events_are_bound: boolean;

--- a/src/services/oidc-helpers.js
+++ b/src/services/oidc-helpers.js
@@ -103,10 +103,9 @@ export const tokenExp = (token) => {
   return null
 }
 
-export const tokenIsExpired = (token) => {
-  const tokenExpiryTime = tokenExp(token)
-  if (tokenExpiryTime) {
-    return tokenExpiryTime < new Date().getTime()
+export const tokenIsExpired = (expiresAt) => {
+  if (expiresAt) {
+    return expiresAt < new Date().getTime()
   }
   return false
 }

--- a/src/store/create-store-module.js
+++ b/src/store/create-store-module.js
@@ -45,6 +45,7 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
     id_token: null,
     refresh_token: null,
     user: null,
+    expires_at: null,
     scopes: null,
     is_checked: false,
     events_are_bound: false,
@@ -124,19 +125,19 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
       return state.user
     },
     oidcAccessToken: (state) => {
-      return tokenIsExpired(state.access_token) ? null : state.access_token
+      return tokenIsExpired(state.expires_at) ? null : state.access_token
     },
     oidcAccessTokenExp: (state) => {
-      return tokenExp(state.access_token)
+      return state.expires_at
     },
     oidcScopes: (state) => {
       return state.scopes
     },
     oidcIdToken: (state) => {
-      return storeSettings.removeUserWhenTokensExpire && tokenIsExpired(state.id_token) ? null : state.id_token
+      return storeSettings.removeUserWhenTokensExpire && tokenExp(state.expires_at) ? null : state.id_token
     },
     oidcIdTokenExp: (state) => {
-      return storeSettings.removeUserWhenTokensExpire ? tokenExp(state.id_token) : null
+      return tokenExp(state.id_token)
     },
     oidcRefreshToken: (state) => {
       return tokenIsExpired(state.refresh_token) ? null : state.refresh_token
@@ -412,12 +413,14 @@ export default (oidcSettings, storeSettings = {}, oidcEventListeners = {}) => {
       state.id_token = user.id_token
       state.access_token = user.access_token
       state.refresh_token = user.refresh_token
+      state.expires_at = user.expires_at ? user.expires_at * 1000 : null
       state.user = user.profile
       state.scopes = user.scopes
       state.error = null
     },
     setOidcUser (state, user) {
       state.user = user ? user.profile : null
+      state.expires_at = user.expires_at ? user.expires_at * 1000 : null
     },
     unsetOidcAuth (state) {
       state.id_token = null


### PR DESCRIPTION
Fix of problem described in #179 

Since access tokens are not always jwts it was incorrect to parse them and check the exp claim. Id tokens and refresh tokens are still parsed as jwts and exp is checked (however if refresh tokens are not valid jwts – which they do not have to be – this will not throw an, but the token will be treated as not expired on the client side.